### PR TITLE
Return 500 for unexpected errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -86,6 +86,8 @@ var root = app.use(
                 if (is_prod) {
                     return errors.errorType['INTERNAL_SERVER_ERROR'];
                 } else {
+                    // Return 500 in development too
+                    error.statusCode = 500;
                     return error;
                 }
             }


### PR DESCRIPTION
This already happens in prod, but in order to have the same consequence
in development, I added the statusCode