### PR TITLE
Sessions Returned by the API should be ordered

### DIFF
--- a/schemas/api_schema.js
+++ b/schemas/api_schema.js
@@ -1,6 +1,7 @@
 var { makeExecutableSchema } = require('graphql-tools');
 var errors = require('./api_schema_errors').errorName;
 const { Kind } = require('graphql/language');
+const { Op } = require('sequelize');
 
 function strip_null(obj) {
     Object.keys(obj).forEach((key) => obj[key] == null && delete obj[key]);
@@ -125,7 +126,13 @@ type Mutation {
             Categories: (parent, args, { db }, info) => db.Category.findAll(),
             FrontSessions: (parent, { start, count }, { db }, info) => {
                 check_sessions_count(count);
-                return db.Session.findAll({ offset: start, limit: count });
+                const now = new Date();
+                return db.Session.findAll({
+                    offset: start,
+                    limit: count,
+                    order: '"start_date" ASC',
+                    where: { end_date: { [Op.gt]: now } }
+                });
             },
             SessionsByUser: (
                 parent,
@@ -134,9 +141,12 @@ type Mutation {
                 info
             ) => {
                 check_sessions_count(count);
+                const now = new Date();
                 return db.Session.findAll({
                     where: { user_id },
-                    limit: count
+                    limit: count,
+                    order: '"start_date" ASC',
+                    where: { end_date: { [Op.gt]: now } }
                 });
             },
             SessionsByCategory: (
@@ -146,9 +156,12 @@ type Mutation {
                 info
             ) => {
                 check_sessions_count(count);
+                const now = new Date();
                 return db.Session.findAll({
                     where: { category },
-                    limit: count
+                    limit: count,
+                    order: '"start_date" ASC',
+                    where: { end_date: { [Op.gt]: now } }
                 });
             },
             ResessionsByUser: (

--- a/schemas/api_schema.js
+++ b/schemas/api_schema.js
@@ -128,10 +128,10 @@ type Mutation {
                 check_sessions_count(count);
                 const now = new Date();
                 return db.Session.findAll({
+                    where: { end_date: { [Op.gt]: now } },
                     offset: start,
                     limit: count,
-                    order: '"start_date" ASC',
-                    where: { end_date: { [Op.gt]: now } }
+                    order: '"start_date" ASC'
                 });
             },
             SessionsByUser: (
@@ -143,10 +143,9 @@ type Mutation {
                 check_sessions_count(count);
                 const now = new Date();
                 return db.Session.findAll({
-                    where: { user_id },
+                    where: { user_id, end_date: { [Op.gt]: now } },
                     limit: count,
-                    order: '"start_date" ASC',
-                    where: { end_date: { [Op.gt]: now } }
+                    order: '"start_date" ASC'
                 });
             },
             SessionsByCategory: (
@@ -158,10 +157,9 @@ type Mutation {
                 check_sessions_count(count);
                 const now = new Date();
                 return db.Session.findAll({
-                    where: { category },
+                    where: { category, end_date: { [Op.gt]: now } },
                     limit: count,
-                    order: '"start_date" ASC',
-                    where: { end_date: { [Op.gt]: now } }
+                    order: '"start_date" ASC'
                 });
             },
             ResessionsByUser: (

--- a/schemas/api_schema.js
+++ b/schemas/api_schema.js
@@ -143,7 +143,7 @@ type Mutation {
                 check_sessions_count(count);
                 const now = new Date();
                 return db.Session.findAll({
-                    where: { user_id, end_date: { [Op.gt]: now } },
+                    where: { user_id },
                     limit: count,
                     order: '"start_date" ASC'
                 });


### PR DESCRIPTION
The order is by their starting date and sessions that ended already
should not appear